### PR TITLE
go.mod: lower module version to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/segmentio/gorocksdb
 
-go 1.22
+go 1.20
 
 require github.com/facebookgo/ensure v0.0.0-20200202191622-63f1cf65ac4c
 


### PR DESCRIPTION
I tested that everything compiles with Go 1.20, so let's try that.